### PR TITLE
Added Pawn-Package Definition file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,7 @@ __pycache__/
 SAMPLauncherNET/obj/Debug/SAMPLauncherNET.csproj.FileListAbsolute.txt
 ./SAMPLauncherNET/bin/
 ./SAMPLauncherNET/obj/
+
+# Pawn Package dependencies and compiled bytecode
+dependencies/
+*.amx

--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,30 @@
+{
+    "user": "BigETI",
+    "repo": "pawn-memory",
+    "entry": "test/memorytest.pwn",
+    "output": "test/memorytest.amx",
+    "dependencies": ["Southclaws/samp-stdlib"],
+    "builds": [
+        {
+            "name": "test",
+            "includes": ["./include"]
+        }
+    ],
+    "runtime": {
+        "plugins": ["BigETI/pawn-memory"]
+    },
+    "resources": [
+        {
+            "name": "pawn-memory-linux-x86.zip",
+            "platform": "linux",
+            "archive": true,
+            "plugins": ["memory.so"]
+        },
+        {
+            "name": "pawn-memory-windows-x86.zip",
+            "platform": "windows",
+            "archive": true,
+            "plugins": ["plugins/pawn-memory.dll"]
+        }
+    ]
+}

--- a/test/memorytest.pwn
+++ b/test/memorytest.pwn
@@ -28,7 +28,7 @@ PrintMemory(Pointer:pointer)
 }
 
 // On filter script init
-public OnFilterScriptInit()
+main()
 {
     new Pointer:pointers[5], EMemoryResult:result, arr[10] = { 100, ... }, arr_copy[sizeof arr], another_arr[sizeof arr] = { 200, ... }, sz, val, UnmanagedPointer:unmanaged_pointers[5], ForeignPointer:foreign_pointer;
     print("[MEMORYTEST] Test 1");


### PR DESCRIPTION
Since [sampctl](https://github.com/Southclaws/sampctl) is getting to the point where it's production-ready, I'm encouraging people to start using it while developing libraries as it should make the process of testing and developing a lot smoother. It's designed so you don't need a `pawn.json`/`pawn.yaml` ("Pawn-Package Definition" file) in every repo, but having it there really helps with dependency management! These changes are purely additive and do not change your code or scripting style in any way, you don't need to use sampctl yourself but I encourage you to [give it a try](https://github.com/Southclaws/sampctl/wiki#installation)!

- added sampctl package files for version control, so a user could now simply run `sampctl package install BigETI/pawn-memory` to start using this library in their gamemode.

- added the `memorytest.pwn` to the `entry` field so you can easily test the code without setting up a full sa-mp server deployment with a gamemode and loading it as a filterscript, simply run `sampctl package run`.

- made a minor change to `memorytest.pwn` to use a gamemode entry point (`main()`) so it can be run with `sampctl package run`

This Pawn Package also contains a `runtime` section so if users add this project as a dependency, it will also automatically download the plugin binaries from the GitHub releases - provided you don't change the file name format that the regular expressions in `pawn.json` match.

---

sampctl is stable but still in development so please give any feedback you have!