### PR TITLE
Added includepath in pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -4,6 +4,7 @@
     "entry": "test/memorytest.pwn",
     "output": "test/memorytest.amx",
     "dependencies": ["Southclaws/samp-stdlib"],
+    "include_path": "include",
     "builds": [
         {
             "name": "test",


### PR DESCRIPTION
This fix the include error which shows cannot read from file "memory"